### PR TITLE
make bar background dark grey

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -45,7 +45,7 @@
 
 /* Simple Bars */
 .bar {
-    padding: 0 12px 10px
+    padding: 0 12px 10px;
 }
 
 .bar__wrap {
@@ -62,6 +62,7 @@
     margin-right: 10px;
     overflow: hidden;
     width: 100px;
+    background: rgb(166, 166, 166);
 }
 
 .bar__inner {


### PR DESCRIPTION
This distinguishes the bar from the background behind. CC @gtrufitt @alastairjardine 
<img width="712" alt="screen shot 2016-06-07 at 17 24 31" src="https://cloud.githubusercontent.com/assets/1764158/15865980/d59534c2-2cd4-11e6-8b16-142011d72e5d.png">
