### PR TITLE
add cache control header

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -7,6 +7,6 @@ npm run eslint
 cp index.html bundle.js poll-static.json build/
 cp css/style.css build/css/style.css
 cp bower_components/pasteup-forms/build/forms.min.css build/bower_components/pasteup-forms/build/
-aws s3 sync build/ s3://gdn-cdn/participation/poll/embed --acl public-read --profile interactivesProd
+aws s3 sync build/ s3://gdn-cdn/participation/poll/embed --acl public-read --cache-control 'max-age=60' --profile interactivesProd
 rm -rf build/
 


### PR DESCRIPTION
Set `cache-control` header so clients don't get cached old versions. CC @gtrufitt 