### PR TITLE
Allow for >2 options

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,16 +12,7 @@
             <span class="form-note total"></span>
         </div>
         <div class="fieldset__fields form-body">
-            <div class="form-field">
-
-                </label>
-                <label class="label" for="q2-input">
-                    <input type="radio" class="pseudo-radio-input" name="option" id="q2-input" value="option-two" required="required">
-                    <div class="pseudo-radio">
-                        <div class="q2"></div>
-                    </div>
-                </label>
-            </div>
+            <div class="form-field"></div>
             <div class="actions">
                 <button class="submit button button--primary button--large" data-link-name="poll-submit">Vote</button>
             </div>

--- a/index.html
+++ b/index.html
@@ -13,11 +13,7 @@
         </div>
         <div class="fieldset__fields form-body">
             <div class="form-field">
-                <label class="label" for="q1-input">
-                    <input type="radio" class="pseudo-radio-input" name="option" id="q1-input" value="option-one" required="required">
-                    <div class="pseudo-radio">
-                        <div class="q1"></div>
-                    </div>
+
                 </label>
                 <label class="label" for="q2-input">
                     <input type="radio" class="pseudo-radio-input" name="option" id="q2-input" value="option-two" required="required">

--- a/main.js
+++ b/main.js
@@ -166,8 +166,9 @@
                     var percentages = [];
                     for (var key in answersObj) {
                         if (answersObj.hasOwnProperty(key)) {
-                            if (resultsForId[key]) {
-                                var percentage = Math.round(resultsForId[key] / total * 100);
+                            var count = resultsForId[key];
+                            if (count) {
+                                var percentage = Math.round(count / total * 100);
                                 percentages.push(percentage);
                             }
                             else {

--- a/main.js
+++ b/main.js
@@ -56,8 +56,7 @@
         if (hasLocalStorage() && localStorage.getItem(localStorageKey) != null) {
             var polls = JSON.parse(localStorage.getItem(localStorageKey));
             return getPollById(polls, id);
-        }
-        else {
+        } else {
             return null;
         }
     }
@@ -88,8 +87,7 @@
                             if (/^a\d+/.test(key)) {
                                 var compressed = (compressString(options[key]));
                                 answersObj[compressed] = options[key];
-                            }
-                            else if (key == 'title') {
+                            } else if (key == 'title') {
                                 metaObj['title'] = options[key];
                             }
                         }
@@ -100,12 +98,10 @@
                     var previousSubmission = getPreviousPollSubmission();
                     if (previousSubmission) {
                         renderResultsFromPollJson(previousSubmission.id, previousSubmission.answer);
-                    }
-                    else {
+                    } else {
                         renderPollForm(id);
                     }
-                }
-                else {
+                } else {
                     // eslint-disable-next-line
                     console && console.warn('No poll found with ID: ' + id);
                 }
@@ -133,8 +129,7 @@
         event.preventDefault();
         if (answer) {
             submitPoll(id, answer);
-        }
-        else {
+        } else {
             // eslint-disable-next-line
             console && console.warn('no answer submitted');
         }
@@ -170,8 +165,7 @@
                             if (count) {
                                 var percentage = Math.round(count / total * 100);
                                 percentages.push(percentage);
-                            }
-                            else {
+                            } else {
                                 //if there are no results then default to 0
                                 percentages.push(0);
                                 percentage = 0;
@@ -194,8 +188,7 @@
                         }
                     });
 
-                }
-                else {
+                } else {
                     //there will be up to 60 seconds latency before first results are published
                     bonzo($('.form-body')[0]).replaceWith(
                         '<div class="pseudo-radio__header q1">Thank you for voting, come back soon to see the results</div>'


### PR DESCRIPTION
Refactor to support >2 poll options.

This works by creating an object with all the options from the Google Sheet JSON, then looping through this to construct the HTML, rather than hardcoding 2 options as previously.

Note there are some whitespace fixes in this PR, so may be simpler to review with `?w=1` param.

CC @gtrufitt 