### PR TITLE
add isClosed field, to close a poll

### DIFF
--- a/main.js
+++ b/main.js
@@ -89,6 +89,8 @@
                                 answersObj[compressed] = options[key];
                             } else if (key == 'title') {
                                 metaObj['title'] = options[key];
+                            } else if (key == 'isClosed') {
+                                metaObj['isClosed'] = options[key].toLowerCase();
                             }
                         }
                     }
@@ -96,7 +98,7 @@
                     bonzo($('.title')[0]).html(metaObj['title']);
                     bonzo($('#form')).removeClass('form-is-hidden');
                     var previousSubmission = getPreviousPollSubmission();
-                    if (previousSubmission) {
+                    if (previousSubmission || metaObj['isClosed'] == 'true') {
                         renderResultsFromPollJson(previousSubmission.id, previousSubmission.answer);
                     } else {
                         renderPollForm(id);


### PR DESCRIPTION
Add option to close a poll, by setting field `isClosed` to `true`. This makes sense as an option particularly where polls are time bound in relevance.

Ideally, I would like polls to auto-close, say after 3 days, but it is difficult to standardise a date stamp in Google sheets, so I think a boolean is a simpler solution for now, though people will have to remember to go back in to close polls.

CC @guardian/participation 
