### PR TITLE
handle case where poll is closed and no previous submission

### DIFF
--- a/main.js
+++ b/main.js
@@ -104,7 +104,7 @@
                         renderResultsFromPollJson(id, null);
                     } else {
                         renderPollForm(id);
-                        }
+                    }
                 } else {
                     // eslint-disable-next-line
                     console && console.warn('No poll found with ID: ' + id);

--- a/main.js
+++ b/main.js
@@ -98,7 +98,7 @@
                     bonzo($('.title')[0]).html(metaObj['title']);
                     bonzo($('#form')).removeClass('form-is-hidden');
                     var previousSubmission = getPreviousPollSubmission();
-                    if (previousSubmission && metaObj['isClosed'] == 'true') {
+                    if (previousSubmission) {
                         renderResultsFromPollJson(previousSubmission.id, previousSubmission.answer);
                     } else if (metaObj['isClosed'] == 'true') {
                         renderResultsFromPollJson(id, null);

--- a/main.js
+++ b/main.js
@@ -98,11 +98,13 @@
                     bonzo($('.title')[0]).html(metaObj['title']);
                     bonzo($('#form')).removeClass('form-is-hidden');
                     var previousSubmission = getPreviousPollSubmission();
-                    if (previousSubmission || metaObj['isClosed'] == 'true') {
+                    if (previousSubmission && metaObj['isClosed'] == 'true') {
                         renderResultsFromPollJson(previousSubmission.id, previousSubmission.answer);
+                    } else if (metaObj['isClosed'] == 'true') {
+                        renderResultsFromPollJson(id, null);
                     } else {
                         renderPollForm(id);
-                    }
+                        }
                 } else {
                     // eslint-disable-next-line
                     console && console.warn('No poll found with ID: ' + id);
@@ -156,7 +158,8 @@
 
                     bonzo($('.total')).html(total + ' votes in total');
 
-                    var userAnswer = answersObj[answer];
+                    var userAnswerHtml = answer ? '<h3 class="pseudo-radio__header ">You voted for "' + answersObj[answer] + '"</h3>' : '';
+
                     var barHtml = '<span class="bar__outer"><span class="bar__inner js-bar__inner"></span></span>';
 
                     var barsHtml = '';
@@ -178,7 +181,7 @@
 
                     bonzo($('.form-body')[0]).replaceWith(
                         '<div class="bar">' +
-                        '<h3 class="pseudo-radio__header ">You voted for "' + userAnswer + '"</h3>' +
+                        userAnswerHtml +
                         barsHtml +
                         '</div>'
                     );


### PR DESCRIPTION
The code erroneously previously always expected there to be a previous submission on the results page, which may not be true for closed polls. Now we only attempt to render the user answer if one is available.

CC @GHaberis 

![screen shot 2016-06-24 at 17 30 28](https://cloud.githubusercontent.com/assets/1764158/16343844/5bb0bdba-3a31-11e6-87c4-043c43f3145f.png)
