### PR TITLE
add option to set closedAfter time

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@
     var formSerialize = require('form-serialize');
     var iframeMessenger = require('iframe-messenger');
     var raf = require('raf');
+    var moment = require('moment');
     var useStaticPoll = false;
 
     var interactiveApi = 'https://interactive.guardianapis.com';
@@ -20,7 +21,6 @@
 
 
     iframeMessenger.enableAutoResize();
-
 
     function compressString(string) {
         return string.replace(/[\s+|\W]/g, '').toLowerCase();
@@ -91,6 +91,14 @@
                                 metaObj['title'] = options[key];
                             } else if (key == 'isClosed') {
                                 metaObj['isClosed'] = options[key].toLowerCase();
+                            } else if (key == 'closedAfter') {
+                                var date = options[key];
+                                if (moment(date, moment.ISO_8601).isValid()) {
+                                    metaObj['closedAfter'] = date;
+                                } else {
+                                    // eslint-disable-next-line
+                                    console && console.warn('closedAfter date is not valid ISO8601');
+                                }
                             }
                         }
                     }
@@ -100,7 +108,7 @@
                     var previousSubmission = getPreviousPollSubmission();
                     if (previousSubmission) {
                         renderResultsFromPollJson(previousSubmission.id, previousSubmission.answer);
-                    } else if (metaObj['isClosed'] == 'true') {
+                    } else if (metaObj['isClosed'] == 'true' || (metaObj['closedAfter']) && moment(metaObj['closedAfter']).isBefore()) {
                         renderResultsFromPollJson(id, null);
                     } else {
                         renderPollForm(id);

--- a/main.js
+++ b/main.js
@@ -87,11 +87,11 @@
                             if (/^a\d+/.test(key)) {
                                 var compressed = (compressString(options[key]));
                                 answersObj[compressed] = options[key];
-                            } else if (key == 'title') {
+                            } else if (key === 'title') {
                                 metaObj['title'] = options[key];
-                            } else if (key == 'isClosed') {
+                            } else if (key === 'isClosed') {
                                 metaObj['isClosed'] = options[key].toLowerCase();
-                            } else if (key == 'closedAfter') {
+                            } else if (key === 'closedAfter') {
                                 var date = options[key];
                                 if (moment(date, moment.ISO_8601).isValid()) {
                                     metaObj['closedAfter'] = date;
@@ -108,7 +108,7 @@
                     var previousSubmission = getPreviousPollSubmission();
                     if (previousSubmission) {
                         renderResultsFromPollJson(previousSubmission.id, previousSubmission.answer);
-                    } else if (metaObj['isClosed'] == 'true' || (metaObj['closedAfter']) && moment(metaObj['closedAfter']).isBefore()) {
+                    } else if (metaObj['isClosed'] === 'true' || (metaObj['closedAfter']) && moment(metaObj['closedAfter']).isBefore()) {
                         renderResultsFromPollJson(id, null);
                     } else {
                         renderPollForm(id);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "browserify": "^13.0.1",
     "form-serialize": "^0.7.1",
     "iframe-messenger": "guardian/iframe-messenger#master",
+    "moment": "^2.13.0",
     "query-string": "^4.1.0",
     "qwery": "^4.0.0",
     "raf": "^3.2.0",

--- a/poll-static.json
+++ b/poll-static.json
@@ -4,7 +4,9 @@
       {
         "title": "What colour is the sky?",
         "a1": "red",
-        "a2": "blue"
+        "a2": "blue",
+        "closedAfter": "2017-07-02T10:19:05+01:00",
+        "isClosed": "false"
       }
     ],
     "myawesomepoll": [


### PR DESCRIPTION
Provided option to close a poll by setting a `closedAfter` date, as an ISO8601 timestamp. 

There is a risk with this, that people will set a date without a timezone and it will default to the user's local time, but I will try to mitigate it in the instructions by telling people to explicitly set a timezone.

